### PR TITLE
add kind for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The code in this repository is split out into a handful of distinct workflows, e
 * `./clusters/eks` contains code for AWS EKS Clusters
 * `./clusters/doks` contains code for Digital Ocean Kubernetes Clusters
 * `./clusters/gke` contains code for Google Cloud GKE Clusters
-* `./clusters/kind` contains code for Kubernetes in Docker (kind) Clusters via `Terraform Kind Provider`
+* `./clusters/kind` contains code for Kubernetes in Docker (kind) Clusters
 
 ### Workload Workflows
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The code in this repository is split out into a handful of distinct workflows, e
 * `./clusters/eks` contains code for AWS EKS Clusters
 * `./clusters/doks` contains code for Digital Ocean Kubernetes Clusters
 * `./clusters/gke` contains code for Google Cloud GKE Clusters
-* `./clusters/kind` contains code for kinD (Kubernetes in Docker) Clusters
+* `./clusters/kind` contains code for Kubernetes in Docker (kind) Clusters
 
 ### Workload Workflows
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The code in this repository is split out into a handful of distinct workflows, e
 * `./clusters/eks` contains code for AWS EKS Clusters
 * `./clusters/doks` contains code for Digital Ocean Kubernetes Clusters
 * `./clusters/gke` contains code for Google Cloud GKE Clusters
-* `./clusters/kind` contains code for Kubernetes in Docker (kind) Clusters
+* `./clusters/kind` contains code for Kubernetes in Docker (kind) Clusters via `Terraform Kind Provider`
 
 ### Workload Workflows
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 - [Multi-Cloud Kubernetes](#multi-cloud-kubernetes)
   - [Table of Contents](#table-of-contents)
   - [Workflows](#workflows)
+    - [Cluster Workflows](#cluster-workflows)
+    - [Workload Workflows](#workload-workflows)
+    - [Other Workflows](#other-workflows)
   - [Author Information](#author-information)
   - [License](#license)
 
@@ -20,6 +23,7 @@ The code in this repository is split out into a handful of distinct workflows, e
 * `./clusters/eks` contains code for AWS EKS Clusters
 * `./clusters/doks` contains code for Digital Ocean Kubernetes Clusters
 * `./clusters/gke` contains code for Google Cloud GKE Clusters
+* `./clusters/kind` contains code for kinD (Kubernetes in Docker) Clusters
 
 ### Workload Workflows
 

--- a/clusters/kind/.terraform.lock.hcl
+++ b/clusters/kind/.terraform.lock.hcl
@@ -1,0 +1,13 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/kyma-incubator/kind" {
+  version     = "0.0.9"
+  constraints = "0.0.9"
+  hashes = [
+    "h1:fjmKlBeOK7Mzqm4bU2v/TWBPFL1t98S3b4ChI9SGiq0=",
+    "zh:402d460a4351d9733ff31de24c39026fb7cb2242d1500f5cf348d17f0ec4643c",
+    "zh:9361aca5e41a0906746605d186424b5404681240f7ed17aeefc5e1afd628ee24",
+    "zh:e8467161989c61adee2d7d50a31535b07a17e27315b993c36d4fb1271a15a7a7",
+  ]
+}

--- a/clusters/kind/README.md
+++ b/clusters/kind/README.md
@@ -4,7 +4,8 @@
 
 ## Requirements
 
-* Terraform CLI `1.0.8` or newer
+* Terraform CLI `1.0.9` or newer
+* ```
 
 ## Downstream Consumption
 

--- a/clusters/kind/README.md
+++ b/clusters/kind/README.md
@@ -1,0 +1,26 @@
+# Workspace `kind`
+
+> This directory contains [kind Provider](https://registry.terraform.io/providers/kyma-incubator/kind/latest) Resources.
+
+## Requirements
+
+* Terraform CLI `1.0.8` or newer
+
+## Downstream Consumption
+
+The Kubernetes Cluster can be consumed via the [kind_cluster](https://kind.sigs.k8s.io/docs/user/quick-start/) data source:
+
+```hcl
+# see https://registry.terraform.io/providers/kyma-incubator/kind/latest/docs/resources/cluster#attributes-reference
+data "kind_cluster" "cluster" {
+  name = "multi-cloud-k8s"
+}
+```
+
+## Execution Mode
+
+Upon terraform initialization, make sure to:
+
+1. YOUR_ORGANIZATION_NAME > Workspaces >YOUR_WORKSPACE_NAME > Settings > General
+1. Switch `Execution Mode`from `Remote` to `Local`
+1. Save the settings

--- a/clusters/kind/README.md
+++ b/clusters/kind/README.md
@@ -9,12 +9,12 @@
 
 ## Downstream Consumption
 
-The Kubernetes Cluster can be consumed via the [kind_cluster](https://kind.sigs.k8s.io/docs/user/quick-start/) data source:
+The Kubernetes Cluster can be consumed via the [attributes reference](https://registry.terraform.io/providers/kyma-incubator/kind/latest/docs/resources/cluster#attributes-reference):
 
 ```hcl
-# see https://registry.terraform.io/providers/kyma-incubator/kind/latest/docs/resources/cluster#attributes-reference
-data "kind_cluster" "cluster" {
-  name = "multi-cloud-k8s"
+output "cluster_config" {
+  description = "Kind Cluster Config."
+  value       = kind_cluster.cluster.kubeconfig
 }
 ```
 

--- a/clusters/kind/main.tf
+++ b/clusters/kind/main.tf
@@ -6,7 +6,8 @@ resource "kind_cluster" "cluster" {
 
 # see https://github.com/kubernetes-sigs/kind/releases
   node_image = "kindest/node:${var.kind_kubernetes_version}"
-  # see https://github.com/kyma-incubator/terraform-provider-kind/blob/master/kind/structure_kind_config.go
+
+# see https://github.com/kyma-incubator/terraform-provider-kind/blob/master/kind/structure_kind_config.go
   kind_config {
     kind        = "Cluster"
     api_version = "kind.x-k8s.io/v1alpha4"
@@ -24,12 +25,15 @@ resource "kind_cluster" "cluster" {
         host_port      = 443
       }
     }
+
     node {
       role = "worker"
     }
+
     node {
       role = "worker"
     }
+
     node {
       role = "worker"
     }

--- a/clusters/kind/main.tf
+++ b/clusters/kind/main.tf
@@ -1,0 +1,36 @@
+# see https://registry.terraform.io/providers/kyma-incubator/kind/latest
+resource "kind_cluster" "cluster" {
+  name            = var.tfe_workspaces_prefix
+  kubeconfig_path = pathexpand(var.kind_cluster_config_path)
+  wait_for_ready  = true
+  # see https://github.com/kubernetes-sigs/kind/releases
+  node_image = "kindest/node:${var.kind_kubernetes_version}"
+  # see https://github.com/kyma-incubator/terraform-provider-kind/blob/master/kind/structure_kind_config.go
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+    node {
+      role = "control-plane"
+      kubeadm_config_patches = [
+        "kind: InitConfiguration\nnodeRegistration:\n  kubeletExtraArgs:\n    node-labels: \"ingress-ready=true\"\n"
+      ]
+      extra_port_mappings {
+        container_port = 80
+        host_port      = 80
+      }
+      extra_port_mappings {
+        container_port = 443
+        host_port      = 443
+      }
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+    node {
+      role = "worker"
+    }
+  }
+}

--- a/clusters/kind/main.tf
+++ b/clusters/kind/main.tf
@@ -3,7 +3,8 @@ resource "kind_cluster" "cluster" {
   name            = var.tfe_workspaces_prefix
   kubeconfig_path = pathexpand(var.kind_cluster_config_path)
   wait_for_ready  = true
-  # see https://github.com/kubernetes-sigs/kind/releases
+
+# see https://github.com/kubernetes-sigs/kind/releases
   node_image = "kindest/node:${var.kind_kubernetes_version}"
   # see https://github.com/kyma-incubator/terraform-provider-kind/blob/master/kind/structure_kind_config.go
   kind_config {

--- a/clusters/kind/main.tf
+++ b/clusters/kind/main.tf
@@ -5,6 +5,7 @@ resource "kind_cluster" "cluster" {
   wait_for_ready  = true
 
 # see https://github.com/kubernetes-sigs/kind/releases
+# ex: v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad
   node_image = "kindest/node:${var.kind_kubernetes_version}"
 
 # see https://github.com/kyma-incubator/terraform-provider-kind/blob/master/kind/structure_kind_config.go

--- a/clusters/kind/main.tf
+++ b/clusters/kind/main.tf
@@ -11,15 +11,19 @@ resource "kind_cluster" "cluster" {
   kind_config {
     kind        = "Cluster"
     api_version = "kind.x-k8s.io/v1alpha4"
+    
     node {
       role = "control-plane"
+      
       kubeadm_config_patches = [
         "kind: InitConfiguration\nnodeRegistration:\n  kubeletExtraArgs:\n    node-labels: \"ingress-ready=true\"\n"
       ]
+      
       extra_port_mappings {
         container_port = 80
         host_port      = 80
       }
+      
       extra_port_mappings {
         container_port = 443
         host_port      = 443

--- a/clusters/kind/outputs.tf
+++ b/clusters/kind/outputs.tf
@@ -32,5 +32,5 @@ output "cluster_endpoint" {
 # this variable is used for testing purposes and has no bearing on the demo
 # see https://www.terraform.io/docs/language/values/outputs.html
 output "workspace_url" {
-  value = "https://app.terraform.io/app/kind-local-organization/workspaces/${var.tfe_workspaces_prefix}-kind"
+  value = "https://app.terraform.io/app/a-demo-organization/workspaces/${var.tfe_workspaces_prefix}-kind"
 }

--- a/clusters/kind/outputs.tf
+++ b/clusters/kind/outputs.tf
@@ -14,6 +14,7 @@ output "cluster_client_certificate" {
 output "cluster_client_key" {
   description = "Kind Cluster Client Key."
   value       = kind_cluster.cluster.client_key
+  sensitive = true
 }
 
 # see https://www.terraform.io/docs/language/values/outputs.html

--- a/clusters/kind/outputs.tf
+++ b/clusters/kind/outputs.tf
@@ -1,0 +1,35 @@
+# see https://www.terraform.io/docs/language/values/outputs.html
+output "cluster_config" {
+  description = "Kind Cluster Config."
+  value       = kind_cluster.cluster.kubeconfig
+}
+
+# see https://www.terraform.io/docs/language/values/outputs.html
+output "cluster_client_certificate" {
+  description = "Kind Cluster Client Certificate."
+  value       = kind_cluster.cluster.client_certificate
+}
+
+# see https://www.terraform.io/docs/language/values/outputs.html
+output "cluster_client_key" {
+  description = "Kind Cluster Client Key."
+  value       = kind_cluster.cluster.client_key
+}
+
+# see https://www.terraform.io/docs/language/values/outputs.html
+output "cluster_ca_certificate" {
+  description = "Kind Cluster CA Certificate."
+  value       = kind_cluster.cluster.cluster_ca_certificate
+}
+
+# see https://www.terraform.io/docs/language/values/outputs.html
+output "cluster_endpoint" {
+  description = "Kind Cluseter Endpoint."
+  value       = kind_cluster.cluster.endpoint
+}
+
+# this variable is used for testing purposes and has no bearing on the demo
+# see https://www.terraform.io/docs/language/values/outputs.html
+output "workspace_url" {
+  value = "https://app.terraform.io/app/kind-local-organization/workspaces/${var.tfe_workspaces_prefix}-kind"
+}

--- a/clusters/kind/providers.tf
+++ b/clusters/kind/providers.tf
@@ -1,0 +1,2 @@
+# see https://registry.terraform.io/providers/kyma-incubator/kind/latest
+provider "kind" {}

--- a/clusters/kind/terraform.tf
+++ b/clusters/kind/terraform.tf
@@ -1,0 +1,23 @@
+terraform {
+  # see https://www.terraform.io/docs/language/settings/backends/remote.html
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "a-demo-organization"
+
+    workspaces {
+      name = "multi-cloud-k8s-kind"
+    }
+  }
+
+  # see https://www.terraform.io/docs/language/settings/index.html#specifying-provider-requirements
+  required_providers {
+    # see https://registry.terraform.io/providers/kyma-incubator/kind/0.0.9
+    kind = {
+      source  = "kyma-incubator/kind"
+      version = "0.0.9"
+    }
+  }
+
+  # see https://www.terraform.io/docs/language/settings/index.html#specifying-a-required-terraform-version
+  required_version = "1.0.9"
+}

--- a/clusters/kind/terraform.tfvars.sample
+++ b/clusters/kind/terraform.tfvars.sample
@@ -1,2 +1,2 @@
-kind_kubernetes_version = "v1.21.1"
+kind_kubernetes_version  = "v1.21.1"
 kind_cluster_config_path = "~/.kube/config"

--- a/clusters/kind/terraform.tfvars.sample
+++ b/clusters/kind/terraform.tfvars.sample
@@ -1,10 +1,2 @@
-variable "kind_kubernetes_version" {
-  type    = string
-  default = "v1.21.1"
-}
-
-variable "kind_cluster_config_path" {
-  type        = string
-  description = "The location where this cluster's kubeconfig will be saved to."
-  default     = "~/.kube/config"
-}
+kind_kubernetes_version = "v1.21.1"
+kind_cluster_config_path = "~/.kube/config"

--- a/clusters/kind/terraform.tfvars.sample
+++ b/clusters/kind/terraform.tfvars.sample
@@ -1,0 +1,10 @@
+variable "kind_kubernetes_version" {
+  type    = string
+  default = "v1.21.1"
+}
+
+variable "kind_cluster_config_path" {
+  type        = string
+  description = "The location where this cluster's kubeconfig will be saved to."
+  default     = "~/.kube/config"
+}

--- a/clusters/kind/variables.tf
+++ b/clusters/kind/variables.tf
@@ -7,7 +7,8 @@ variable "tfe_workspaces_prefix" {
 # see https://github.com/kubernetes-sigs/kind/releases
 # The default node image is a Kubernetes v1.21.1
 variable "kind_kubernetes_version" {
-  type    = string
+  type            = string
+  description = "Kubernetes version to use with Kind Cluster."
   default = "v1.21.1"
 }
 

--- a/clusters/kind/variables.tf
+++ b/clusters/kind/variables.tf
@@ -1,0 +1,18 @@
+variable "tfe_workspaces_prefix" {
+  type        = string
+  description = "Prefix for TFE Workspaces."
+  default     = "multi-cloud-k8s"
+}
+
+# see https://github.com/kubernetes-sigs/kind/releases
+# The default node image is a Kubernetes v1.21.1
+variable "kind_kubernetes_version" {
+  type    = string
+  default = "v1.21.1"
+}
+
+variable "kind_cluster_config_path" {
+  type        = string
+  description = "The location where this cluster's kubeconfig will be saved to."
+  default     = "~/.kube/config"
+}

--- a/clusters/kind/variables.tf
+++ b/clusters/kind/variables.tf
@@ -5,11 +5,10 @@ variable "tfe_workspaces_prefix" {
 }
 
 # see https://github.com/kubernetes-sigs/kind/releases
-# The default node image is a Kubernetes v1.21.1
 variable "kind_kubernetes_version" {
-  type            = string
+  type        = string
   description = "Kubernetes version to use with Kind Cluster."
-  default = "v1.21.1"
+  default     = "v1.21.1"
 }
 
 variable "kind_cluster_config_path" {

--- a/clusters/kind/variables.tf
+++ b/clusters/kind/variables.tf
@@ -8,7 +8,7 @@ variable "tfe_workspaces_prefix" {
 variable "kind_kubernetes_version" {
   type        = string
   description = "Kubernetes version to use with Kind Cluster."
-  default     = "v1.21.1"
+  default     = "v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad"
 }
 
 variable "kind_cluster_config_path" {

--- a/outputs/variables.tf
+++ b/outputs/variables.tf
@@ -7,7 +7,8 @@ variable "tfe_workspaces" {
     "aks",
     "eks",
     "doks",
-    "gke"
+    "gke",
+    "kind"
   ]
 }
 

--- a/workspaces/variables.tf
+++ b/workspaces/variables.tf
@@ -38,6 +38,10 @@ variable "tfe_workspaces" {
     execution_mode    = "remote"
     working_directory = "/clusters/gke"
     }, {
+    description       = "Manages Kind Clusters."
+    execution_mode    = "remote"
+    working_directory = "/clusters/kind"
+    }, {
     description       = "Collects Terraform Cloud Workspace Outputs."
     execution_mode    = "remote"
     working_directory = "/outputs"


### PR DESCRIPTION
This addition will allow to spin up a local KinD cluster.

! One small caveat is we have to change the setting of a workspace from `remote` to `local` via the UI for now, when running from within the `kind` folder